### PR TITLE
feat: improve post visibility filtering

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test test/*.test.js"
   },
   "repository": {
     "type": "git",

--- a/post_api.js
+++ b/post_api.js
@@ -342,7 +342,12 @@ module.exports = function (app, hexo, use) {
         };
 
         const blogInfoList = loadBlogInfoList()
-        const fuse = new Fuse(blogInfoList, fuseOptions);
+        const includeDraft = req.body.includeDraft !== false && req.body.includeDraft !== 'false'
+        const searchableList = includeDraft
+        ? blogInfoList
+        : blogInfoList.filter(item => item.isDraft !== true && item.isDraft !== 'true')
+
+        const fuse = new Fuse(searchableList, fuseOptions);
 
         const results = fuse.search(req.body.searchPattern)
         // 返回搜索结果
@@ -386,7 +391,9 @@ module.exports = function (app, hexo, use) {
         clonedList.map(addIsDraft);
 
         let finalList = [];
-        if (published == 'true') {
+        if (published === 'all') {
+        finalList = clonedList.filter(post => post.isDiscarded === false);
+        } else if (published == 'true') {
             finalList = clonedList.filter(post => post.isDraft === false && post.isDiscarded === false);
         } else {
             finalList = clonedList.filter(post => post.isDraft === true);

--- a/post_api.js
+++ b/post_api.js
@@ -344,8 +344,8 @@ module.exports = function (app, hexo, use) {
         const blogInfoList = loadBlogInfoList()
         const includeDraft = req.body.includeDraft !== false && req.body.includeDraft !== 'false'
         const searchableList = includeDraft
-        ? blogInfoList
-        : blogInfoList.filter(item => item.isDraft !== true && item.isDraft !== 'true')
+            ? blogInfoList
+            : blogInfoList.filter(item => item.isDraft !== true && item.isDraft !== 'true')
 
         const fuse = new Fuse(searchableList, fuseOptions);
 
@@ -392,7 +392,7 @@ module.exports = function (app, hexo, use) {
 
         let finalList = [];
         if (published === 'all') {
-        finalList = clonedList.filter(post => post.isDiscarded === false);
+            finalList = clonedList.filter(post => post.isDiscarded === false);
         } else if (published == 'true') {
             finalList = clonedList.filter(post => post.isDraft === false && post.isDiscarded === false);
         } else {

--- a/test/post_visibility_filter.test.js
+++ b/test/post_visibility_filter.test.js
@@ -1,0 +1,103 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const test = require('node:test')
+
+const registerPostApi = require('../post_api')
+
+function createResponse() {
+    return {
+        payload: undefined,
+        done(payload) {
+            this.payload = payload
+        }
+    }
+}
+
+function createHexo(posts, baseDir) {
+    return {
+        base_dir: baseDir,
+        model(name) {
+            assert.equal(name, 'Post')
+            return {
+                toArray() {
+                    return posts
+                }
+            }
+        }
+    }
+}
+
+function registerHandlers(hexo) {
+    const handlers = {}
+    registerPostApi(null, hexo, (route, handler) => {
+        handlers[route] = handler
+    })
+    return handlers
+}
+
+function listPosts(handlers, query) {
+    const res = createResponse()
+    handlers['posts/list']({ url: `/hexopro/api/posts/list?${query}` }, res)
+    return res.payload
+}
+
+function searchBlog(handlers, body) {
+    const res = createResponse()
+    handlers['blog/search']({ body }, res)
+    return res.payload.data
+}
+
+function makePost(title, source, date) {
+    return {
+        title,
+        source,
+        date,
+        updated: date,
+        permalink: `/${title}/`,
+        isDiscarded: false
+    }
+}
+
+test('posts/list published=all returns published and draft posts without discarded posts', () => {
+    const posts = [
+        makePost('published', '_posts/published.md', '2024-01-01T00:00:00.000Z'),
+        makePost('draft', '_drafts/draft.md', '2024-01-02T00:00:00.000Z'),
+        makePost('discarded', '_discarded/123/discarded.md', '2024-01-03T00:00:00.000Z')
+    ]
+    const handlers = registerHandlers(createHexo(posts, os.tmpdir()))
+
+    const result = listPosts(handlers, 'published=all')
+
+    assert.deepEqual(result.data.map(post => post.title), ['draft', 'published'])
+    assert.equal(result.total, 2)
+})
+
+test('posts/list published=false returns drafts without discarded posts', () => {
+    const posts = [
+        makePost('draft', '_drafts/draft.md', '2024-01-02T00:00:00.000Z'),
+        makePost('discarded', '_discarded/123/discarded.md', '2024-01-03T00:00:00.000Z')
+    ]
+    const handlers = registerHandlers(createHexo(posts, os.tmpdir()))
+
+    const result = listPosts(handlers, 'published=false')
+
+    assert.deepEqual(result.data.map(post => post.title), ['draft'])
+    assert.equal(result.total, 1)
+})
+
+test('blog/search includeDraft=false excludes drafts while default keeps them', () => {
+    const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hexo-pro-search-'))
+    fs.writeFileSync(path.join(baseDir, 'blogInfoList.json'), JSON.stringify([
+        { title: 'Published match', content: 'visible keyword', isPage: false, isDraft: false, permalink: '/published/' },
+        { title: 'Draft match', content: 'draft keyword', isPage: false, isDraft: true, permalink: '/draft/' }
+    ]))
+    const handlers = registerHandlers(createHexo([], baseDir))
+
+    const defaultResults = searchBlog(handlers, { searchPattern: 'keyword' })
+    const publishedOnlyResults = searchBlog(handlers, { searchPattern: 'keyword', includeDraft: 'false' })
+
+    assert.deepEqual(defaultResults.map(item => item.title).sort(), ['Draft match', 'Published match'])
+    assert.deepEqual(publishedOnlyResults.map(item => item.title), ['Published match'])
+})


### PR DESCRIPTION
文章相关 API 中的文章可见性过滤功能。

修改内容
- 为 `posts/list` 添加 `published=all` 支持。
- 为 `blog/search` 添加 `includeDraft=false` 支持。
- 当未传入 `includeDraft` 时，保留原有搜索行为。

测试
- `posts/list?published=true` 返回已发布文章。
- `posts/list?published=false` 返回草稿文章。
- `posts/list?published=all` 同时返回已发布文章和草稿文章。
- `blog/search` 默认会返回草稿搜索结果。
- `blog/search` 携带 `includeDraft=false` 时会排除草稿文章。